### PR TITLE
Overhaul Snippet Generation For Functions, Allow `/` In Import Statements

### DIFF
--- a/lib/gocodeprovider.js
+++ b/lib/gocodeprovider.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import {CompositeDisposable, Point} from 'atom'
+import {CompositeDisposable} from 'atom'
 import path from 'path'
 import _ from 'lodash'
 

--- a/lib/gocodeprovider.js
+++ b/lib/gocodeprovider.js
@@ -1,6 +1,6 @@
 'use babel'
 
-import {CompositeDisposable} from 'atom'
+import {CompositeDisposable, Point} from 'atom'
 import path from 'path'
 import _ from 'lodash'
 
@@ -85,7 +85,14 @@ class GocodeProvider {
     return false
   }
 
-  characterIsSuppressed (char) {
+  characterIsSuppressed (char, scopeDescriptor) {
+    if (scopeDescriptor && scopeDescriptor.scopes && scopeDescriptor.scopes.length > 0) {
+      for (let scope of scopeDescriptor.scopes) {
+        if (scope === 'entity.name.import.go') {
+          return false
+        }
+      }
+    }
     return this.suppressForCharacters.indexOf(char) !== -1
   }
 
@@ -101,8 +108,14 @@ class GocodeProvider {
       }
 
       let index = buffer.characterIndexForPosition(options.bufferPosition)
+      let priorBufferPosition = options.bufferPosition.copy()
+      priorBufferPosition.column
+      if (priorBufferPosition.column > 0) {
+        priorBufferPosition.column = priorBufferPosition.column - 1
+      }
+      let scopeDescriptor = options.editor.scopeDescriptorForBufferPosition(priorBufferPosition)
       let text = options.editor.getText()
-      if (index > 0 && this.characterIsSuppressed(text[index - 1])) {
+      if (index > 0 && this.characterIsSuppressed(text[index - 1], scopeDescriptor)) {
         return resolve()
       }
       let offset = Buffer.byteLength(text.substring(0, index), 'utf8')

--- a/lib/gocodeprovider.js
+++ b/lib/gocodeprovider.js
@@ -42,7 +42,7 @@ class GocodeProvider {
       this.snippetMode = value
     })
     this.subscriptions.add(snippetModeSubscription)
-    this.funcRegex = /^(?:func[(]{1})([^\)]*)(?:[)]{1})(?:$|(?:\s)([^\(]*$)|(?: [(]{1})([^\)]*)(?:[)]{1}))/i
+    // this.funcRegex = /^(?:func[(]{1})((?:(?![)][\s$]).)*)(?:[)]{1})(?:$|(?:\s[(]{1}|\s)((?:(?![)$]).)*)(?:[)]{1}$|$))/i
   }
 
   dispose () {
@@ -58,7 +58,6 @@ class GocodeProvider {
     this.suppressForCharacters = null
     this.snippetMode = null
     this.disableForSelector = null
-    this.funcRegex = null
   }
 
   ready () {
@@ -221,74 +220,402 @@ class GocodeProvider {
     return type
   }
 
+  matchFunc (type) {
+    if (!type || !type.startsWith('func(')) {
+      return
+    }
+
+    let count = 0
+    let args
+    let returns
+    let returnsStart = 0
+    for (let i = 0; i < type.length; i++) {
+      if (type[i] === '(') {
+        count = count + 1
+      }
+
+      if (type[i] === ')') {
+        count = count - 1
+        if (count === 0) {
+          args = type.substring('func('.length, i)
+          returnsStart = i + ') '.length
+          break
+        }
+      }
+    }
+
+    if (type.length > returnsStart) {
+      if (type[returnsStart] === '(') {
+        returns = type.substring(returnsStart + 1, type.length - 1)
+      } else {
+        returns = type.substring(returnsStart, type.length)
+      }
+    }
+
+    return [type, args, returns]
+  }
+
+  parseType (type) {
+    if (!type || type.trim() === '') {
+      return {
+        isFunc: false,
+        name: '',
+        args: [],
+        returns: []
+      }
+    }
+    let match = this.matchFunc(type)
+    if (!match || !match[0]) {
+      return {
+        isFunc: false,
+        name: type,
+        match: match,
+        args: [],
+        returns: []
+      }
+    }
+
+    let a = match[1]
+    let r = match[2]
+    if (!a && !r) {
+      return {
+        isFunc: true,
+        name: type,
+        match: match,
+        args: [],
+        returns: []
+      }
+    }
+
+    return {
+      isFunc: true,
+      name: type,
+      match: match,
+      args: this.parseParameters(a),
+      returns: this.parseParameters(r)
+    }
+  }
+
+  ensureNextArg (args) {
+    if (!args || args.length === 0) {
+      return false
+    }
+
+    let arg = args[0]
+    let hasFunc = false
+    if (arg.includes('func(')) {
+      hasFunc = true
+    }
+    if (!hasFunc) {
+      return args
+    }
+    let start = 4
+    if (!arg.startsWith('func(')) {
+      let splitArg = arg.split(' ')
+      if (!splitArg || splitArg.length < 2 || !splitArg[1].startsWith('func(')) {
+        return args
+      }
+      start = splitArg[0].length + 5
+    }
+
+    let funcArg = args.join(', ')
+    let end = 0
+    let count = 0
+    for (let i = start; i < funcArg.length; i++) {
+      if (funcArg[i] === '(') {
+        count = count + 1
+      } else if (funcArg[i] === ')') {
+        count = count - 1
+        if (count === 0) {
+          end = i + 1
+          break
+        }
+      }
+    }
+
+    arg = funcArg.substring(0, end)
+    if (arg.length === funcArg.length || !funcArg.substring(end + 2, funcArg.length).includes(', ')) {
+      return [funcArg.trim()]
+    }
+
+    if (funcArg[end + 1] === '(') {
+      for (let i = end + 1; i < funcArg.length; i++) {
+        if (funcArg[i] === '(') {
+          count = count + 1
+        } else if (funcArg[i] === ')') {
+          count = count - 1
+          if (count === 0) {
+            end = i + 1
+            break
+          }
+        }
+      }
+    }
+
+    arg = funcArg.substring(0, end)
+    if (arg.length === funcArg.length || !funcArg.substring(end + 2, funcArg.length).includes(', ')) {
+      return [funcArg.trim()]
+    }
+
+    for (let i = end; i < funcArg.length; i++) {
+      if (funcArg[i] === ',') {
+        arg = arg + funcArg.substring(end, i)
+        end = i + 1
+        break
+      }
+    }
+
+    args = funcArg.substring(end + 1, funcArg.length).trim().split(', ')
+    args.unshift(arg.trim())
+    return args
+  }
+
+  parseParameters (p) {
+    if (!p || p.trim() === '') {
+      return []
+    }
+    let args = p.split(/, /)
+    let result = []
+    let more = true
+    while (more) {
+      args = this.ensureNextArg(args)
+      if (!args) {
+        more = false
+        continue
+      }
+      let arg = args.shift()
+      let identifier = ''
+      let type = ''
+
+      if (arg.startsWith('func')) {
+        result.push({isFunc: true, name: arg, identifier: '', type: this.parseType(arg)})
+        continue
+      }
+      if (!arg.includes(' ')) {
+        result.push({isFunc: false, name: arg, identifier: '', type: arg})
+        continue
+      }
+
+      let split = arg.split(' ')
+      if (!split || split.length < 2) {
+        continue
+      }
+
+      identifier = split.shift()
+      type = split.join(' ')
+      let isFunc = false
+      if (type.startsWith('func')) {
+        type = this.parseType(split.join(' '))
+        isFunc = true
+      }
+      result.push({isFunc: isFunc, name: arg, identifier: identifier, type: type})
+    }
+
+    return result
+  }
+
   upgradeSuggestion (suggestion, c) {
-    if (!c || !c.type || c.type === '') {
+    if (!c || !c.type || c.type === '' || !c.type.includes('func(')) {
       return suggestion
     }
-    let match = this.funcRegex.exec(c.type)
-    if (!match || !match[0]) { // Not a function
-      suggestion.snippet = c.name + '()'
+    let type = this.parseType(c.type)
+    if (!type || !type.isFunc) {
       suggestion.leftLabel = ''
       return suggestion
     }
-    suggestion.leftLabel = match[2] || match[3] || ''
+    suggestion.leftLabel = ''
+    if (type.returns && type.returns.length > 0) {
+      if (type.returns.length === 1) {
+        suggestion.leftLabel = type.returns[0].name
+      } else {
+        suggestion.leftLabel = '('
+        for (let r of type.returns) {
+          if (suggestion.leftLabel === '(') {
+            suggestion.leftLabel = suggestion.leftLabel + r.name
+          } else {
+            suggestion.leftLabel = suggestion.leftLabel + ', ' + r.name
+          }
+        }
+        suggestion.leftLabel = suggestion.leftLabel + ')'
+      }
+    }
 
-    let res = this.generateSnippet(c.name, match)
+    let res = this.generateSnippet(c.name, type)
     suggestion.snippet = res.snippet
     suggestion.displayText = res.displayText
     return suggestion
   }
 
-  generateSnippet (name, match) {
-    let signature = {
-      snippet: name,
-      displayText: name
+  funcSnippet (result, snipCount, argCount, param) {
+    // Generate an anonymous func
+    let identifier = param.identifier
+    if (!identifier || !identifier.length) {
+      identifier = 'arg' + argCount
     }
+    snipCount = snipCount + 1
+    result.snippet = result.snippet + '${' + snipCount + ':'
+    result.snippet = result.snippet + 'func('
+    result.displayText = result.displayText + 'func('
+    let internalArgCount = 0
+    for (let arg of param.type.args) {
+      internalArgCount = internalArgCount + 1
+      if (internalArgCount !== 1) {
+        result.snippet = result.snippet + ', '
+        result.displayText = result.displayText + ', '
+      }
 
-    if (!match || !match[1] || match[1] === '') {
-      // Has no arguments
-      return {
-        snippet: name + '()$0',
-        displayText: name + '()'
+      snipCount = snipCount + 1
+      let argText = 'arg' + argCount + ''
+      if (arg.identifier && arg.identifier.length > 0) {
+        argText = arg.identifier + ''
       }
-    }
-
-    let args = match[1].split(/, /)
-    args = _.map(args, (a) => {
-      if (!a || a.length <= 2) {
-        return {display: a, snippet: a}
-      }
-      if (a.substring(a.length - 2, a.length) === '{}') {
-        return {display: a, snippet: a.substring(0, a.length - 1) + '\\}'}
-      }
-      return {display: a, snippet: a}
-    })
-
-    let i = 1
-    for (let arg of args) {
-      if (this.snippetMode === 'name') {
-        let parts = arg.snippet.split(' ')
-        arg.snippet = parts[0]
-      }
-      if (i === 1) {
-        signature.snippet = name + '(${' + i + ':' + arg.snippet + '}'
-        signature.displayText = name + '(' + arg.display
+      result.snippet = result.snippet + '${' + snipCount + ':' + argText + '} '
+      result.displayText = result.displayText + argText + ' '
+      if (arg.isFunc) {
+        let r = this.funcSnippet(result, snipCount, argCount, arg)
+        result = r.result
+        snipCount = r.snipCount
+        argCount = r.argCount
       } else {
-        signature.snippet = signature.snippet + ', ${' + i + ':' + arg.snippet + '}'
-        signature.displayText = signature.displayText + ', ' + arg.display
+        let argType = arg.type
+        if (argType.endsWith('{}')) {
+          argType = argType.substring(0, argType.length - 1) + '\\}'
+        }
+        result.snippet = result.snippet + argType
+        result.displayText = result.displayText + arg.type
       }
-      i = i + 1
+    }
+    result.snippet = result.snippet + ')'
+    result.displayText = result.displayText + ')'
+    if (param.type.returns && param.type.returns.length) {
+      if (param.type.returns.length === 1) {
+        if (param.type.returns[0].isFunc) {
+          result.snippet = result.snippet + ' '
+          result.displayText = result.displayText + ' '
+          let r = this.funcSnippet(result, snipCount, argCount, param.type.returns[0])
+          result = r.result
+          snipCount = r.snipCount
+          argCount = r.argCount
+        } else {
+          result.snippet = result.snippet + ' ' + param.type.returns[0].type
+          if (result.snippet.endsWith('{}')) {
+            result.snippet = result.snippet.substring(0, result.snippet.length - 1) + '\\}'
+          }
+          result.displayText = result.displayText + ' ' + param.type.returns[0].name
+        }
+      } else {
+        let returnCount = 0
+        result.snippet = result.snippet + ' ('
+        result.displayText = result.displayText + ' ('
+        for (let returnItem of param.type.returns) {
+          returnCount = returnCount + 1
+          if (returnCount !== 1) {
+            result.snippet = result.snippet + ', '
+            result.displayText = result.displayText + ', '
+          }
+          let returnType = returnItem.type
+          if (returnType.endsWith('{}')) {
+            returnType = returnType.substring(0, returnType.length - 1) + '\\}'
+          }
+          result.snippet = result.snippet + returnType
+          result.displayText = result.displayText + returnItem.name
+        }
+        result.snippet = result.snippet + ')'
+        result.displayText = result.displayText + ')'
+      }
     }
 
-    signature.snippet = signature.snippet + ')$0'
-    signature.displayText = signature.displayText + ')'
+    snipCount = snipCount + 1
+    result.snippet = result.snippet + ' {\n\t$' + snipCount + '\n\\}}'
+    return {
+      result: result,
+      snipCount: snipCount,
+      argCount: argCount
+    }
+  }
 
+  generateSnippet (name, type) {
+    let result = {
+      snippet: name + '(',
+      displayText: name + '('
+    }
+
+    if (!type) {
+      result.snippet = result.snippet + ')$0'
+      result.displayText = result.displayText + ')'
+      return result
+    }
+    let snipCount = 0
+    let argCount = 0
+    for (let arg of type.args) {
+      argCount = argCount + 1
+      if (argCount !== 1) {
+        result.snippet = result.snippet + ', '
+        result.displayText = result.displayText + ', '
+      }
+      if (arg.isFunc) {
+        let r = this.funcSnippet(result, snipCount, argCount, arg)
+        result = r.result
+        snipCount = r.snipCount
+        argCount = r.argCount
+      } else {
+        let argText = arg.name
+        if (this.snippetMode === 'name' && arg.identifier && arg.identifier.length) {
+          argText = arg.identifier
+        }
+        if (argText.endsWith('{}')) {
+          argText = argText.substring(0, argText.length - 1) + '\\}'
+        }
+        snipCount = snipCount + 1
+        result.snippet = result.snippet + '${' + snipCount + ':' + argText + '}'
+        result.displayText = result.displayText + arg.name
+      }
+    }
+
+    result.snippet = result.snippet + ')$0'
+    result.displayText = result.displayText + ')'
     if (this.snippetMode === 'none') {
       // user doesn't care about arg names/types
-      signature.snippet = name + '($0)'
+      result.snippet = name + '($1)$0'
     }
-
-    return signature
+    return result
+    //
+    // let args = type.args
+    // args = _.map(args, (a) => {
+    //   if (!a || a.length <= 2) {
+    //     return {display: a, snippet: a}
+    //   }
+    //   if (a.substring(a.length - 2, a.length) === '{}') {
+    //     return {display: a, snippet: a.substring(0, a.length - 1) + '\\}'}
+    //   }
+    //   return {display: a, snippet: a}
+    // })
+    //
+    // let i = 1
+    // for (let arg of args) {
+    //   if (this.snippetMode === 'name') {
+    //     let parts = arg.snippet.split(' ')
+    //     arg.snippet = parts[0]
+    //   }
+    //   if (i === 1) {
+    //     signature.snippet = name + '(${' + i + ':' + arg.snippet + '}'
+    //     signature.displayText = name + '(' + arg.display
+    //   } else {
+    //     signature.snippet = signature.snippet + ', ${' + i + ':' + arg.snippet + '}'
+    //     signature.displayText = signature.displayText + ', ' + arg.display
+    //   }
+    //   i = i + 1
+    // }
+    //
+    // signature.snippet = signature.snippet + ')$0'
+    // signature.displayText = signature.displayText + ')'
+    //
+    // if (this.snippetMode === 'none') {
+    //   // user doesn't care about arg names/types
+    //   signature.snippet = name + '($1)$0'
+    // }
+    //
+    // return signature
   }
 }
 export {GocodeProvider}

--- a/lib/gocodeprovider.js
+++ b/lib/gocodeprovider.js
@@ -15,7 +15,7 @@ class GocodeProvider {
     this.inclusionPriority = 1
     this.excludeLowerPriority = atom.config.get('autocomplete-go.suppressBuiltinAutocompleteProvider')
     this.suppressForCharacters = []
-    this.disableForSelector = atom.config.get('autocomplete-go.scopeBlacklist')
+    this.filterSelectors()
     let suppressSubscription = atom.config.observe('autocomplete-go.suppressActivationForCharacters', (value) => {
       this.suppressForCharacters = _.map(value, (c) => {
         let char = c ? c.trim() : ''
@@ -42,7 +42,6 @@ class GocodeProvider {
       this.snippetMode = value
     })
     this.subscriptions.add(snippetModeSubscription)
-    // this.funcRegex = /^(?:func[(]{1})((?:(?![)][\s$]).)*)(?:[)]{1})(?:$|(?:\s[(]{1}|\s)((?:(?![)$]).)*)(?:[)]{1}$|$))/i
   }
 
   dispose () {
@@ -58,6 +57,23 @@ class GocodeProvider {
     this.suppressForCharacters = null
     this.snippetMode = null
     this.disableForSelector = null
+  }
+
+  filterSelectors () {
+    let configSelectors = atom.config.get('autocomplete-go.scopeBlacklist')
+    this.shouldSuppressStringQuoted = false
+    let selectors = []
+    if (configSelectors && configSelectors.length) {
+      for (let selector of configSelectors.split(',')) {
+        selector = selector.trim()
+        if (selector.includes('.string.quoted')) {
+          this.shouldSuppressStringQuoted = true
+        } else {
+          selectors.push(selector)
+        }
+      }
+    }
+    this.disableForSelector = selectors.join(', ')
   }
 
   ready () {
@@ -90,6 +106,13 @@ class GocodeProvider {
       for (let scope of scopeDescriptor.scopes) {
         if (scope === 'entity.name.import.go') {
           return false
+        }
+
+        if (this.shouldSuppressStringQuoted && scope && scope.startsWith('string.quoted')) {
+          if (scopeDescriptor.scopes.indexOf('entity.name.import.go') !== -1) {
+            return false
+          }
+          return true
         }
       }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -90,11 +90,17 @@ export default {
   toggleGocodeConfig () {
     if (this.goconfig) {
       this.goconfig.locator.findTool('gocode').then((cmd) => {
+        if (!this.goconfig) {
+          return
+        }
         this.goconfig.executor.exec(cmd, ['set', 'unimported-packages', this.unimportedPackages]).then((r) => {
           if (r.stderr && r.stderr.trim() !== '') {
             console.log('autocomplete-go: (stderr) ' + r.stderr)
           }
         }).then(() => {
+          if (!this.goconfig) {
+            return
+          }
           return this.goconfig.executor.exec(cmd, ['set', 'propose-builtins', this.proposeBuiltins]).then((r) => {
             if (r.stderr && r.stderr.trim() !== '') {
               console.log('autocomplete-go: (stderr) ' + r.stderr)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.16.2"
   },
   "devDependencies": {
-    "standard": "^8.2.0"
+    "standard": "^8.3.0"
   },
   "package-deps": [
     "go-config",

--- a/spec/gocodeprovider-spec.js
+++ b/spec/gocodeprovider-spec.js
@@ -109,6 +109,650 @@ describe('gocodeprovider', () => {
     }
   })
 
+  describe('matchFunc', () => {
+    let t = (context) => {
+      let match = provider.matchFunc(context.input)
+      expect(match).toBeTruthy()
+      expect(match.length).toBe(3)
+      expect(match[0]).toBe(context.input)
+      expect(match[1]).toBe(context.args)
+      expect(match[2]).toBe(context.returns)
+    }
+
+    it('identifies function arguments', () => {
+      t({
+        input: 'func(name string, flag bool) bool',
+        args: 'name string, flag bool',
+        returns: 'bool'
+      })
+      t({
+        input: 'func(name string, flag bool) (bool)',
+        args: 'name string, flag bool',
+        returns: 'bool'
+      })
+      t({
+        input: 'func(name string, f func(t *testing.T)) bool',
+        args: 'name string, f func(t *testing.T)',
+        returns: 'bool'
+      })
+      t({
+        input: 'func(name string, f func(t *testing.T)) (bool)',
+        args: 'name string, f func(t *testing.T)',
+        returns: 'bool'
+      })
+      t({
+        input: 'func(name string, f func(t *testing.T) int) (bool)',
+        args: 'name string, f func(t *testing.T) int',
+        returns: 'bool'
+      })
+      t({
+        input: 'func(pattern string, handler func(http.ResponseWriter, *http.Request))',
+        args: 'pattern string, handler func(http.ResponseWriter, *http.Request)',
+        returns: undefined
+      })
+      t({
+        input: 'func(n int) func(p *T)',
+        args: 'n int',
+        returns: 'func(p *T)'
+      })
+    })
+  })
+
+  describe('parseType', () => {
+    let t = (context) => {
+      let result = provider.parseType(context.input)
+      expect(result).toBeTruthy()
+      expect(result.isFunc).toBeTruthy()
+      expect(result.args).toEqual(context.args)
+      expect(result.returns).toEqual(context.returns)
+    }
+
+    it('parses the function into args and returns arrays', () => {
+      t({
+        input: 'func(name string, flag bool) bool',
+        args: [{
+          isFunc: false,
+          name: 'name string',
+          identifier: 'name',
+          type: 'string'
+        }, {
+          isFunc: false,
+          name: 'flag bool',
+          identifier: 'flag',
+          type: 'bool'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(name string, flag bool) (bool)',
+        args: [{
+          isFunc: false,
+          name: 'name string',
+          identifier: 'name',
+          type: 'string'
+        }, {
+          isFunc: false,
+          name: 'flag bool',
+          identifier: 'flag',
+          type: 'bool'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(name string, f func(t *testing.T)) bool',
+        args: [{
+          isFunc: false,
+          name: 'name string',
+          identifier: 'name',
+          type: 'string'
+        }, {
+          isFunc: true,
+          name: 'f func(t *testing.T)',
+          identifier: 'f',
+          type: {
+            isFunc: true,
+            name: 'func(t *testing.T)',
+            match: ['func(t *testing.T)', 't *testing.T', undefined],
+            args: [{
+              isFunc: false,
+              name: 't *testing.T',
+              identifier: 't',
+              type: '*testing.T'
+            }],
+            returns: []
+          }
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(name string, f func(t *testing.T)) (bool)',
+        args: [{
+          isFunc: false,
+          name: 'name string',
+          identifier: 'name',
+          type: 'string'
+        }, {
+          isFunc: true,
+          name: 'f func(t *testing.T)',
+          identifier: 'f',
+          type: {
+            isFunc: true,
+            name: 'func(t *testing.T)',
+            match: ['func(t *testing.T)', 't *testing.T', undefined],
+            args: [{
+              isFunc: false,
+              name: 't *testing.T',
+              identifier: 't',
+              type: '*testing.T'
+            }],
+            returns: []
+          }
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(pattern string, handler func(http.ResponseWriter, *http.Request))',
+        args: [{
+          isFunc: false,
+          name: 'pattern string',
+          identifier: 'pattern',
+          type: 'string'
+        }, {
+          isFunc: true,
+          name: 'handler func(http.ResponseWriter, *http.Request)',
+          identifier: 'handler',
+          type: {
+            isFunc: true,
+            name: 'func(http.ResponseWriter, *http.Request)',
+            match: ['func(http.ResponseWriter, *http.Request)', 'http.ResponseWriter, *http.Request', undefined],
+            args: [{
+              isFunc: false,
+              name: 'http.ResponseWriter',
+              identifier: '',
+              type: 'http.ResponseWriter'
+            }, {
+              isFunc: false,
+              name: '*http.Request',
+              identifier: '',
+              type: '*http.Request'
+            }],
+            returns: []
+          }
+        }],
+        returns: []
+      })
+      t({
+        input: 'func(pattern string, handler func(http.ResponseWriter, *http.Request), otherhandler func(http.ResponseWriter, *http.Request))',
+        args: [{
+          isFunc: false,
+          name: 'pattern string',
+          identifier: 'pattern',
+          type: 'string'
+        }, {
+          isFunc: true,
+          name: 'handler func(http.ResponseWriter, *http.Request)',
+          identifier: 'handler',
+          type: {
+            isFunc: true,
+            name: 'func(http.ResponseWriter, *http.Request)',
+            match: ['func(http.ResponseWriter, *http.Request)', 'http.ResponseWriter, *http.Request', undefined],
+            args: [{
+              isFunc: false,
+              name: 'http.ResponseWriter',
+              identifier: '',
+              type: 'http.ResponseWriter'
+            }, {
+              isFunc: false,
+              name: '*http.Request',
+              identifier: '',
+              type: '*http.Request'
+            }],
+            returns: []
+          }
+        }, {
+          isFunc: true,
+          name: 'otherhandler func(http.ResponseWriter, *http.Request)',
+          identifier: 'otherhandler',
+          type: {
+            isFunc: true,
+            name: 'func(http.ResponseWriter, *http.Request)',
+            match: ['func(http.ResponseWriter, *http.Request)', 'http.ResponseWriter, *http.Request', undefined],
+            args: [{
+              isFunc: false,
+              name: 'http.ResponseWriter',
+              identifier: '',
+              type: 'http.ResponseWriter'
+            }, {
+              isFunc: false,
+              name: '*http.Request',
+              identifier: '',
+              type: '*http.Request'
+            }],
+            returns: []
+          }
+        }],
+        returns: []
+      })
+      t({
+        input: 'func(pattern string, handler func(w http.ResponseWriter, r *http.Request), otherhandler func(w http.ResponseWriter, r *http.Request))',
+        args: [{
+          isFunc: false,
+          name: 'pattern string',
+          identifier: 'pattern',
+          type: 'string'
+        }, {
+          isFunc: true,
+          name: 'handler func(w http.ResponseWriter, r *http.Request)',
+          identifier: 'handler',
+          type: {
+            isFunc: true,
+            name: 'func(w http.ResponseWriter, r *http.Request)',
+            match: ['func(w http.ResponseWriter, r *http.Request)', 'w http.ResponseWriter, r *http.Request', undefined],
+            args: [{
+              isFunc: false,
+              name: 'w http.ResponseWriter',
+              identifier: 'w',
+              type: 'http.ResponseWriter'
+            }, {
+              isFunc: false,
+              name: 'r *http.Request',
+              identifier: 'r',
+              type: '*http.Request'
+            }],
+            returns: []
+          }
+        }, {
+          isFunc: true,
+          name: 'otherhandler func(w http.ResponseWriter, r *http.Request)',
+          identifier: 'otherhandler',
+          type: {
+            isFunc: true,
+            name: 'func(w http.ResponseWriter, r *http.Request)',
+            match: ['func(w http.ResponseWriter, r *http.Request)', 'w http.ResponseWriter, r *http.Request', undefined],
+            args: [{
+              isFunc: false,
+              name: 'w http.ResponseWriter',
+              identifier: 'w',
+              type: 'http.ResponseWriter'
+            }, {
+              isFunc: false,
+              name: 'r *http.Request',
+              identifier: 'r',
+              type: '*http.Request'
+            }],
+            returns: []
+          }
+        }],
+        returns: []
+      })
+      t({
+        input: 'func()',
+        args: [],
+        returns: []
+      })
+      t({
+        input: 'func(x int) int',
+        args: [{
+          isFunc: false,
+          name: 'x int',
+          identifier: 'x',
+          type: 'int'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'int',
+          identifier: '',
+          type: 'int'
+        }]
+      })
+      t({
+        input: 'func(a, _ int, z float32) bool',
+        args: [{
+          isFunc: false,
+          name: 'a',
+          identifier: '',
+          type: 'a'
+        }, {
+          isFunc: false,
+          name: '_ int',
+          identifier: '_',
+          type: 'int'
+        }, {
+          isFunc: false,
+          name: 'z float32',
+          identifier: 'z',
+          type: 'float32'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(a, b int, z float32) (bool)',
+        args: [{
+          isFunc: false,
+          name: 'a',
+          identifier: '',
+          type: 'a'
+        }, {
+          isFunc: false,
+          name: 'b int',
+          identifier: 'b',
+          type: 'int'
+        }, {
+          isFunc: false,
+          name: 'z float32',
+          identifier: 'z',
+          type: 'float32'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'bool',
+          identifier: '',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(a, b int, z float64, opt ...interface{}) (success bool)',
+        args: [{
+          isFunc: false,
+          name: 'a',
+          identifier: '',
+          type: 'a'
+        }, {
+          isFunc: false,
+          name: 'b int',
+          identifier: 'b',
+          type: 'int'
+        }, {
+          isFunc: false,
+          name: 'z float64',
+          identifier: 'z',
+          type: 'float64'
+        }, {
+          isFunc: false,
+          name: 'opt ...interface{}',
+          identifier: 'opt',
+          type: '...interface{}'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'success bool',
+          identifier: 'success',
+          type: 'bool'
+        }]
+      })
+      t({
+        input: 'func(prefix string, values ...int)',
+        args: [{
+          isFunc: false,
+          name: 'prefix string',
+          identifier: 'prefix',
+          type: 'string'
+        }, {
+          isFunc: false,
+          name: 'values ...int',
+          identifier: 'values',
+          type: '...int'
+        }],
+        returns: []
+      })
+      t({
+        input: 'func(int, int, float64) (float64, *[]int)',
+        args: [{
+          isFunc: false,
+          name: 'int',
+          identifier: '',
+          type: 'int'
+        }, {
+          isFunc: false,
+          name: 'int',
+          identifier: '',
+          type: 'int'
+        }, {
+          isFunc: false,
+          name: 'float64',
+          identifier: '',
+          type: 'float64'
+        }],
+        returns: [{
+          isFunc: false,
+          name: 'float64',
+          identifier: '',
+          type: 'float64'
+        }, {
+          isFunc: false,
+          name: '*[]int',
+          identifier: '',
+          type: '*[]int'
+        }]
+      })
+      t({
+        input: 'func(n int) func(p *T)',
+        args: [{
+          isFunc: false,
+          name: 'n int',
+          identifier: 'n',
+          type: 'int'
+        }],
+        returns: [{
+          isFunc: true,
+          name: 'func(p *T)',
+          identifier: '',
+          type: {
+            isFunc: true,
+            name: 'func(p *T)',
+            match: ['func(p *T)', 'p *T', undefined],
+            args: [{
+              isFunc: false,
+              name: 'p *T',
+              identifier: 'p',
+              type: '*T'
+            }],
+            returns: []
+          }
+        }]
+      })
+    })
+  })
+
+  describe('generateSnippet', () => {
+    let t = (context) => {
+      let result = provider.generateSnippet(context.input.name, context.input.type)
+      expect(result).toBeTruthy()
+      expect(result).toBeTruthy()
+      expect(result).toEqual(context.result)
+    }
+
+    it('parses the function into args and returns arrays', () => {
+      t({
+        input: {
+          name: 'Print',
+          type: {
+            match: ['func()', undefined, undefined],
+            isFunc: true,
+            name: 'func()',
+            args: [],
+            returns: []
+          }
+        },
+        result: {
+          snippet: 'Print()$0',
+          displayText: 'Print()'
+        }
+      })
+      t({
+        input: {
+          name: 'Print',
+          type: {
+            match: ['func(x int) int', 'x int', 'int'],
+            isFunc: true,
+            name: 'func(x int) int',
+            args: [{
+              isFunc: false,
+              name: 'x int',
+              identifier: 'x',
+              type: 'int'
+            }],
+            returns: [{
+              isFunc: false,
+              name: 'int',
+              identifier: '',
+              type: 'int'
+            }]
+          }
+        },
+        result: {
+          snippet: 'Print(${1:x int})$0', // eslint-disable-line no-template-curly-in-string
+          displayText: 'Print(x int)'
+        }
+      })
+      t({
+        input: {
+          name: 'ServeFunc',
+          type: {
+            match: ['func(pattern string, func(w http.ResponseWriter, r *http.Request))', 'pattern string, func(w http.ResponseWriter, r *http.Request)', undefined],
+            isFunc: true,
+            name: 'func(pattern string, func(w http.ResponseWriter, r *http.Request))',
+            args: [{
+              isFunc: false,
+              name: 'pattern string',
+              identifier: 'pattern',
+              type: 'string'
+            }, {
+              isFunc: true,
+              name: 'func(w http.ResponseWriter, r *http.Request)',
+              identifier: '',
+              type: {
+                isFunc: true,
+                name: 'func(w http.ResponseWriter, r *http.Request)',
+                match: ['func(w http.ResponseWriter, r *http.Request)', 'w http.ResponseWriter, r *http.Request', undefined],
+                args: [{
+                  isFunc: false,
+                  name: 'w http.ResponseWriter',
+                  identifier: 'w',
+                  type: 'http.ResponseWriter'
+                }, {
+                  isFunc: false,
+                  name: 'r *http.Request',
+                  identifier: 'r',
+                  type: '*http.Request'
+                }],
+                returns: []
+              }
+            }],
+            returns: []
+          }
+        },
+        result: {
+          snippet: 'ServeFunc(${1:pattern string}, ${2:func(${3:w} http.ResponseWriter, ${4:r} *http.Request) {\n\t$5\n\\}})$0', // eslint-disable-line no-template-curly-in-string
+          displayText: 'ServeFunc(pattern string, func(w http.ResponseWriter, r *http.Request))'
+        }
+      })
+      t({
+        input: {
+          name: 'Bleh',
+          type: {
+            match: ['func(f func() int)', 'f func() int', undefined],
+            isFunc: true,
+            name: 'func(f func() int)',
+            args: [{
+              isFunc: true,
+              name: 'f func() int',
+              identifier: 'f',
+              type: {
+                isFunc: true,
+                name: 'func() int',
+                match: ['func() int', undefined, 'int'],
+                args: [],
+                returns: [{
+                  isFunc: false,
+                  name: 'int',
+                  identifier: '',
+                  type: 'int'
+                }]
+              }
+            }],
+            returns: []
+          }
+        },
+        result: {
+          snippet: 'Bleh(${1:func() int {\n\t$2\n\\}})$0', // eslint-disable-line no-template-curly-in-string
+          displayText: 'Bleh(func() int)'
+        }
+      })
+      /*
+      func(x int) int
+      func(a, _ int, z float32) bool
+      func(a, b int, z float32) (bool)
+      func(prefix string, values ...int)
+      func(a, b int, z float64, opt ...interface{}) (success bool)
+      func(int, int, float64) (float64, *[]int)
+      func(n int) func(p *T)
+      */
+    })
+  })
+
+  describe('upgradeSuggestion', () => {
+    it('parses params', () => {
+      let result = provider.ensureNextArg(['f func() int'])
+      expect(result).toEqual(['f func() int'])
+      result = provider.ensureNextArg(['f func() int, s string'])
+      expect(result).toEqual(['f func() int', 's string'])
+      result = provider.ensureNextArg(['f func(s1 string, i1 int) int, s string'])
+      expect(result).toEqual(['f func(s1 string, i1 int) int', 's string'])
+    })
+    it('generates snippets', () => {
+      let result = provider.upgradeSuggestion({}, {
+        name: 'Abc',
+        type: 'func(f func() int)'
+      })
+      expect(result.displayText).toBe('Abc(func() int)')
+      expect(result.snippet).toBe('Abc(${1:func() int {\n\t$2\n\\}})$0') // eslint-disable-line no-template-curly-in-string
+      result = provider.upgradeSuggestion({}, {
+        name: 'Abc',
+        type: 'func(f func() interface{})'
+      })
+      expect(result.displayText).toBe('Abc(func() interface{})')
+      expect(result.snippet).toBe('Abc(${1:func() interface{\\} {\n\t$2\n\\}})$0') // eslint-disable-line no-template-curly-in-string
+      result = provider.upgradeSuggestion({}, {
+        name: 'Abc',
+        type: 'func(f func() (interface{}, interface{}))'
+      })
+      expect(result.displayText).toBe('Abc(func() (interface{}, interface{}))')
+      expect(result.snippet).toBe('Abc(${1:func() (interface{\\}, interface{\\}) {\n\t$2\n\\}})$0') // eslint-disable-line no-template-curly-in-string
+      result = provider.upgradeSuggestion({}, {
+        name: 'Abc',
+        type: 'func(f interface{})'
+      })
+      expect(result.displayText).toBe('Abc(f interface{})')
+      expect(result.snippet).toBe('Abc(${1:f interface{\\}})$0') // eslint-disable-line no-template-curly-in-string
+    })
+  })
+
   describe('when the basic file is opened', () => {
     beforeEach(() => {
       waitsForPromise(() => {
@@ -155,7 +799,7 @@ describe('gocodeprovider', () => {
           expect(suggestions[0].snippet).toBe('Print(${1:a ...interface{\\}})$0') // eslint-disable-line no-template-curly-in-string
           expect(suggestions[0].replacementPrefix).toBe('P')
           expect(suggestions[0].type).toBe('function')
-          expect(suggestions[0].leftLabel).toBe('n int, err error')
+          expect(suggestions[0].leftLabel).toBe('(n int, err error)')
           editor.backspace()
         })
       })
@@ -197,7 +841,7 @@ describe('gocodeprovider', () => {
           expect(suggestions[0].snippet).toBe('Print(${1:a})$0') // eslint-disable-line no-template-curly-in-string
           expect(suggestions[0].replacementPrefix).toBe('P')
           expect(suggestions[0].type).toBe('function')
-          expect(suggestions[0].leftLabel).toBe('n int, err error')
+          expect(suggestions[0].leftLabel).toBe('(n int, err error)')
           editor.backspace()
         })
       })
@@ -236,10 +880,10 @@ describe('gocodeprovider', () => {
           expect(suggestions.length).toBeGreaterThan(0)
           expect(suggestions[0]).toBeTruthy()
           expect(suggestions[0].displayText).toBe('Print(a ...interface{})')
-          expect(suggestions[0].snippet).toBe('Print($0)')
+          expect(suggestions[0].snippet).toBe('Print($1)$0')
           expect(suggestions[0].replacementPrefix).toBe('P')
           expect(suggestions[0].type).toBe('function')
-          expect(suggestions[0].leftLabel).toBe('n int, err error')
+          expect(suggestions[0].leftLabel).toBe('(n int, err error)')
           editor.backspace()
         })
       })


### PR DESCRIPTION
- Generate anonymous funcs for functions with func args
- Generate return type for functions with func args
- Expand the placeholder for func args to include the entire function
- Include parens in the ac+ leftLabel field for functions with multiple return arguments 
- Allow autocompletion in import declarations, when paired with https://github.com/atom/language-go/pull/97

Fixes https://github.com/joefitzgerald/go-plus/issues/441
Fixes https://github.com/joefitzgerald/go-plus/issues/226
